### PR TITLE
fix: Use fedora registry to not hit the dockerhub pull limit on quay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM registry.fedoraproject.org/fedora:32
 
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 


### PR DESCRIPTION
Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>