### PR TITLE
Use fedora:34 tag for fedora 34 instead of latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:latest
+FROM registry.fedoraproject.org/fedora:34
 
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 


### PR DESCRIPTION
Signed-off-by: Tibor Dudlák <tdudlak@redhat.com>